### PR TITLE
Allow override of Ansible file operations path

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ please uses the `sensu_settings` variable, that will generate the
 `sensu_install_client`|Boolean|Determine if we need to install the client part|`true`
 `sensu_install_server`|Boolean|Determine if we need to install the server part|`true`
 `sensu_install_uchiwa`|Boolean|Determine if we need to install the uchiwa. Will only work in `sensu_install_server` is also true|`true`
+`sensu_file_base`|String|Base path for Ansible file operations. Allows for overriding source path for handlers, extensions, and plugins|`""`
 
 ### General variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # defaults file for sensu
 
+sensu_file_base: ''
+
 # Variable to control the installation
 sensu_install_client: true
 sensu_install_server: true

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -21,7 +21,7 @@
 
 - name: copy the handlers files
   copy:
-    src=files/sensu/handlers/
+    src="{{sensu_file_base}}files/sensu/handlers/"
     dest=/etc/sensu/handlers/
     owner=sensu
     group=sensu
@@ -29,7 +29,7 @@
 
 - name: copy extension files
   copy:
-    src=files/sensu/extensions/
+    src="{{sensu_file_base}}files/sensu/extensions/"
     dest=/etc/sensu/extensions/
     owner=sensu
     group=sensu
@@ -39,7 +39,7 @@
 
 - name: copy plugins files
   copy:
-    src=files/sensu/plugins/
+    src="{{sensu_file_base}}files/sensu/plugins/"
     dest=/etc/sensu/plugins/
     owner=sensu
     group=sensu


### PR DESCRIPTION
Adds a variable to allow for custom `src` file paths for handler, extension, and plugin file operations.

Defaults to empty to match previous behavior.