### PR TITLE
Add option to pull RabbitMQ certs from S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ files/
  └── sensu_client_key.pem
 ```
 
+Optionally RabbitMQ certificates can be retrieved from an S3 bucket. The system where Ansible runs must have authorization to access this bucket in order to use this feature. See `sensu_rabbitmq_ssl_from_s3`, `sensu_rabbitmq_ssl_s3_bucket`, and `sensu_rabbitmq_ssl_s3_path` Ansible variables for configuration.
+
 Note that you can find a complete set of certificates and keys in
 `vagrant/files/` for **test purpose only**. Be smart, don't use certificates &
 keys publicly available in production! You can also customize this path, see
@@ -115,6 +117,10 @@ please uses the `sensu_settings` variable, that will generate the
 `sensu_cert_dir`|String|Directory to look for the certificates|`files`
 `sensu_cert_file_name`|String|Filename of the client certificate|`sensu_client_cert.pem`
 `sensu_key_file_name`|String|Filename of the client key|`sensu_client_key.pem`
+`sensu_rabbitmq_ssl_from_s3`|Boolean|Determine if we should pull RabbitMQ SSL certificates from an S3 buckets|`false`
+`sensu_rabbitmq_ssl_s3_bucket`|String|Name of the S3 bucket containing RabbitMQ certificates|`""`
+`sensu_rabbitmq_ssl_s3_path`|String|Path within the S3 bucket where RabbitMQ certificates are stored|`""`
+
 
 ### Client variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,10 @@ sensu_server_rabbitmq_insecure: false
 sensu_server_rabbitmq_user:     "sensu"
 sensu_server_rabbitmq_password: "placeholder"
 
+sensu_rabbitmq_ssl_from_s3: False
+sensu_rabbitmq_ssl_s3_bucket: ""
+sensu_rabbitmq_ssl_s3_path: ""
+
 sensu_server_dashboard_host:     "0.0.0.0"
 sensu_server_dashboard_port:     "3000"
 sensu_server_dashboard_user:     "uchiwa"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -37,6 +37,19 @@
     state=directory
   when: not sensu_server_rabbitmq_insecure
 
+- name: pull rabbit ssl client certificates from s3
+  s3:
+    bucket: "{{ sensu_rabbitmq_ssl_s3_bucket }}"
+    object: "{{ sensu_rabbitmq_ssl_s3_path }}/{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: get
+  with_items:
+    - src: "{{ sensu_cert_file_name }}"
+      dest: "/etc/sensu/ssl/{{ sensu_cert_file_name }}"
+    - src: "{{ sensu_key_file_name }}"
+      dest: "/etc/sensu/ssl/{{ sensu_key_file_name }}"
+  when: sensu_rabbitmq_ssl_from_s3
+
 - name: copy the SSL certificate & key
   copy:
     src={{ sensu_cert_dir }}/{{ item }}
@@ -48,7 +61,7 @@
   with_items:
     - "{{ sensu_cert_file_name }}"
     - "{{ sensu_key_file_name }}"
-  when: not sensu_server_rabbitmq_insecure
+  when: not sensu_server_rabbitmq_insecure and not sensu_rabbitmq_ssl_from_s3
   notify:
     - restart sensu server
     - restart sensu client


### PR DESCRIPTION
## Testing
This change is tested and in use via Hinge's vagrant environment.