### PR TITLE
Allow override of client source file path

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -1,7 +1,7 @@
 ---
 - name: copy all the checks files
   copy:
-    src=files/sensu/plugins/
+    src="{{ sensu_file_base }}files/sensu/plugins/"
     dest=/etc/sensu/plugins/
     owner="{{ sensu_user }}"
     group="{{ sensu_group }}"


### PR DESCRIPTION
This builds on a previously merged PR that allows overriding where file resources are pulled from. One file source was missed in the original PR.

## Testing
This change is tested and in use via Hinge's vagrant environment.