### PR TITLE
Filters and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ anymore, but split all the files in the `/etc/sensu/conf.d` folder:
     ├── checks.json
     ├── client.json
     ├── handlers.json
+    ├── filters.json
     ├── rabbitmq.json
     ├── redis.json
     └── settings.json
@@ -118,6 +119,7 @@ Some plugins depend on installed gems. Required gems can be installed via Sensu'
 `sensu_group`|String|the group running sensu|`sensu`
 `sensu_checks`|Complex type|A variable representing the checks configuration. Will be auto converted to JSON|`[]`
 `sensu_handlers`|Complex type|A variable representing the handlers configuration. Will be auto converted to JSON|`[]`
+`sensu_filters`|Complex type|A variable representing the filter configuration. Will be auto converted to JSON|`[]`
 `sensu_embedded_ruby`|String|Indicate if Sensu should use the embedded Ruby, or the system one|`"true"`
 `sensu_cert_dir`|String|Directory to look for the certificates|`files`
 `sensu_cert_file_name`|String|Filename of the client certificate|`sensu_client_cert.pem`
@@ -135,6 +137,7 @@ Some plugins depend on installed gems. Required gems can be installed via Sensu'
 `sensu_client_hostname`|String|Hostname of this client|`"{{ ansible_hostname }}"`
 `sensu_client_address`|String|Address of this client|`"{{ ansible_default_ipv4.address }}"`
 `sensu_client_subscription_names`|List|List of test to execute on this client| `[test]`
+`sensu_client_attributes`|Object|Additional attributes to set for the client|None
 
 ### Server variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,7 +58,6 @@ sensu_server_dashboard_refresh:  5
 
 sensu_checks:   []
 sensu_handlers: []
+sensu_filters: []
 
 sensu_server_patch_init_scripts: true
-
-

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -60,6 +60,7 @@
     - api
     - settings
     - checks
+    - filters
   notify:
     - restart sensu server
 

--- a/templates/client.json.j2
+++ b/templates/client.json.j2
@@ -2,6 +2,11 @@
    "client": {
       "name": "{{ sensu_client_hostname }}",
       "address": "{{ sensu_client_address }}",
+{% if sensu_client_attributes is defined %}
+{% for item,value in sensu_client_attributes.iteritems() %}
+      "{{ item }}": "{{ value }}",
+{% endfor %}
+{% endif %}
       "subscriptions": [ "{{ "\",\"".join(sensu_client_subscription_names) }}" ]
    }
 }

--- a/templates/filters.json.j2
+++ b/templates/filters.json.j2
@@ -1,0 +1,4 @@
+{
+   "filters":
+      {{ sensu_filters | to_nice_json }}
+}


### PR DESCRIPTION
- adding support for filters on the server
- adding support to set client side attributes

This adds the ability to set attributes on the clients and also filters for controlling handlers. For example The client can set an environment such as production:

```yaml
sensu_client_attributes:
  environment: "production"
```

Which can then be used to see if pagerduty alarm should be triggered via a filter on the server:

```yaml
sensu_filters:
  production: {attributes: {client: {environment: production}}, negate: false}

sensu_handlers:
  pagerduty:
    type   : pipe
    command: "/etc/sensu/handlers/pagerduty.rb"
    filters: [ "production" ]
    severities:
      - "critical"
      - "ok"
```