### PR TITLE
change to allow for redact and keepalive

### DIFF
--- a/templates/client.json.j2
+++ b/templates/client.json.j2
@@ -4,7 +4,7 @@
       "address": "{{ sensu_client_address }}",
 {% if sensu_client_attributes is defined %}
 {% for item,value in sensu_client_attributes.iteritems() %}
-      "{{ item }}": "{{ value }}",
+      "{{ item }}": {{ value | to_json }},
 {% endfor %}
 {% endif %}
       "subscriptions": [ "{{ "\",\"".join(sensu_client_subscription_names) }}" ]


### PR DESCRIPTION
@davekonopka I would appreciate a +1. This PR makes the client attributes for sensu a bit cleaner and allows to set the `redact`  as a list (rather than as a separate attribute) and now allows to add `keepalive` as dict